### PR TITLE
Fix: switch Users.id to AutoField to match INT(11) SQL schema

### DIFF
--- a/application/backend/api/models.py
+++ b/application/backend/api/models.py
@@ -27,7 +27,7 @@ class Users(AbstractUser):
         db_table = 'Users'
 
     # Primary key
-    id = models.IntegerField(primary_key=True)
+    id = models.AutoField(primary_key=True)
     email = models.EmailField(max_length=100, unique=True)
     username = models.CharField(max_length=50, unique=True)
     password = models.CharField(max_length=100)

--- a/application/backend/sql/02-create_tables.sql
+++ b/application/backend/sql/02-create_tables.sql
@@ -1,6 +1,6 @@
 -- USERS TABLE
 CREATE TABLE `Users` (
-  `id`             INT AUTO_INCREMENT PRIMARY KEY,
+  `id`             INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `password`       VARCHAR(128)            NOT NULL,
   `last_login`     DATETIME                NULL,
   `is_superuser`   BOOLEAN    NOT NULL DEFAULT FALSE,
@@ -12,94 +12,93 @@ CREATE TABLE `Users` (
   `date_joined`    DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `isAdmin`        BOOLEAN    NOT NULL DEFAULT FALSE,
   `is_staff`       BOOLEAN    NOT NULL DEFAULT FALSE,
-  `profile_id`     INT        UNIQUE,
+  `profile_id`     INT(11)    UNIQUE,
   `profile_image`  VARCHAR(255),
   `bio`            TEXT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-
 -- POSTS TABLE
-CREATE TABLE Posts (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    creator_id INT NOT NULL,
-    date DATETIME DEFAULT CURRENT_TIMESTAMP, # automatically sets to current date/time when post is created
-    text TEXT,
-    image VARCHAR(255), # image URL or path
-    FOREIGN KEY (creator_id) REFERENCES Users(id)
+CREATE TABLE `Posts` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `creator_id` INT(11) NOT NULL,
+    `date` DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,  # automatically sets to current date/time when post is created
+    `text` TEXT,
+    `image` VARCHAR(255),
+    FOREIGN KEY (`creator_id`) REFERENCES `Users`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- COMMENTS TABLE
-CREATE TABLE Comments (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    post_id INT NOT NULL,
-    author_id INT NOT NULL,
-    content TEXT NOT NULL,
-    date DATETIME DEFAULT CURRENT_TIMESTAMP, # automatically sets to current date/time when comment is created
-    FOREIGN KEY (post_id) REFERENCES Posts(id)
+CREATE TABLE `Comments` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `post_id` INT(11) NOT NULL,
+    `author_id` INT(11) NOT NULL,
+    `content` TEXT NOT NULL,
+    `date` DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`post_id`) REFERENCES `Posts`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE,
-    FOREIGN KEY (author_id) REFERENCES Users(id)
+    FOREIGN KEY (`author_id`) REFERENCES `Users`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- ACHIEVEMENTS TABLE
-CREATE TABLE Achievements (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(100) NOT NULL,
-    description TEXT,
-    icon VARCHAR(255) # image URL or path for the achievement icon
-);
+CREATE TABLE `Achievements` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `title` VARCHAR(100)   NOT NULL,
+    `description` TEXT,
+    `icon` VARCHAR(255) # image URL or path for the achievement icon
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- CHALLENGES TABLE
-CREATE TABLE Challenges (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(100) NOT NULL,
-    description TEXT,
-    target_amount FLOAT,
-    current_progress FLOAT DEFAULT 0,
-    is_public BOOLEAN DEFAULT FALSE, # whether the challenge can be participated by all users or only by the creator
-    reward_id INT,
-    FOREIGN KEY (reward_id) REFERENCES Achievements(id)
+CREATE TABLE `Challenges` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `title` VARCHAR(100)   NOT NULL,
+    `description` TEXT,
+    `target_amount` FLOAT,
+    `current_progress` FLOAT NOT NULL DEFAULT 0,
+    `is_public` BOOLEAN    NOT NULL DEFAULT FALSE,  # whether the challenge can be participated by all users or only by the creator
+    `reward_id` INT(11),
+    FOREIGN KEY (`reward_id`) REFERENCES `Achievements`(`id`)
         ON DELETE SET NULL
         ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- USER-CHALLENGE RELATIONSHIP TABLE
 # For keeping track of all the challenges a user participates in
-CREATE TABLE UserChallenges (
-    user_id INT,
-    challenge_id INT,
-    joined_date DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (user_id, challenge_id),
-    FOREIGN KEY (user_id) REFERENCES Users(id)
+CREATE TABLE `UserChallenges` (
+    `user_id` INT(11) NOT NULL,
+    `challenge_id` INT(11) NOT NULL,
+    `joined_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`user_id`, `challenge_id`),
+    FOREIGN KEY (`user_id`) REFERENCES `Users`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE,
-    FOREIGN KEY (challenge_id) REFERENCES Challenges(id)
+    FOREIGN KEY (`challenge_id`) REFERENCES `Challenges`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE
-);
-
-
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- USER-ACHIEVEMENT RELATIONSHIP TABLE
-CREATE TABLE UserAchievements (
-    user_id INT,
-    achievement_id INT,
-    earned_at DATETIME DEFAULT CURRENT_TIMESTAMP, # automatically sets to current date/time when achievement is earned
-    PRIMARY KEY (user_id, achievement_id),
-    FOREIGN KEY (user_id) REFERENCES Users(id)
+CREATE TABLE `UserAchievements` (
+    `user_id` INT(11) NOT NULL,
+    `achievement_id` INT(11) NOT NULL,
+    `earned_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`user_id`, `achievement_id`),
+    FOREIGN KEY (`user_id`) REFERENCES `Users`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE,
-    FOREIGN KEY (achievement_id) REFERENCES Achievements(id)
+    FOREIGN KEY (`achievement_id`) REFERENCES `Achievements`(`id`)
         ON DELETE CASCADE
         ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- TIPS TABLE
-CREATE TABLE Tips (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    text TEXT NOT NULL,
-    like_count INT DEFAULT 0,
-    dislike_count INT DEFAULT 0
-);
+CREATE TABLE `Tips` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `text` TEXT    NOT NULL,
+    `like_count` INT(11) NOT NULL DEFAULT 0,
+    `dislike_count` INT(11) NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## What
Changed the `Users` model’s primary key from `BigAutoField` to `AutoField` so it maps to `INT(11)` in MySQL and matches our existing SQL-init script.

## Why
Django was failing on migrations with an FK mismatch between `django_admin_log.user_id (INT)` and Users.id (BIGINT). Switching to AutoField (32-bit) resolves the incompatibility.

## How I tested
1. Tear down & rebuild:

```
docker compose down -v
docker compose up --build -d
```

2. Ran migrations inside the container:

```
docker compose exec web python manage.py migrate
```

3. Verified no FK errors and confirmed the app boots and responds at `http://localhost:8000`.

Related to #127. I believe this might resolve the issue, but would like confirmation before closing.