### PR TITLE
merge feature/display-current-user-in-leaderboard into main

### DIFF
--- a/application/backend/api/waste/waste_views.py
+++ b/application/backend/api/waste/waste_views.py
@@ -152,28 +152,62 @@ def get_user_wastes(request):
 def get_top_users(request):
     """
     Get top 10 users with most total waste contributions (as points and CO2 emission).
-    Returns a list of users with their total CO2 emissions.
+    Returns:
+     - A list of top 10 users with their total CO2 emissions and points
+     - Current user's stats and standing in the leaderboard (if authenticated)
     """
     try:
-        # Get top 10 users who have waste records, sorted by total CO2
-        users_with_waste = Users.objects.filter(
+        # Get all users who have waste records, sorted by total points
+        all_users_with_waste = Users.objects.filter(
             id__in=UserWastes.objects.values('user_id')
-        ).order_by('-total_points')[:10]
+        ).order_by('-total_points')
         
-        # Prepare response data
-        response_data = []
-        for user in users_with_waste:
-            response_data.append({
+        # For leaderboard: get top 10 users
+        top_users = all_users_with_waste[:10]
+        
+        # Prepare response data for top users
+        top_users_data = []
+        for index, user in enumerate(top_users):
+            top_users_data.append({
+                'rank': index + 1,
                 'username': user.username,
                 'total_waste': f"{user.total_co2:.4f}",  # CO2 emission formatted to 4 decimals
                 'profile_picture': user.profile_image_url,
                 'points': user.total_points,
             })
+        
+        # Prepare response
+        response_data = {
+            'top_users': top_users_data
+        }
+        
+        # Add current user info if authenticated
+        if request.user.is_authenticated:
+            try:
+                # Find user's position in the leaderboard
+                user_rank = None
+                for index, user in enumerate(all_users_with_waste):
+                    if user.id == request.user.id:
+                        user_rank = index + 1
+                        break
+                
+                # Get user stats
+                user_stats = {
+                    'username': request.user.username,
+                    'total_waste': f"{request.user.total_co2:.4f}",
+                    'profile_picture': request.user.profile_image_url,
+                    'points': request.user.total_points,
+                    'rank': user_rank if user_rank else 'Not ranked'
+                }
+                
+                response_data['current_user'] = user_stats
+            except Exception as e:
+                # If there's an error getting current user info, continue without it
+                response_data['current_user'] = {'error': 'Could not retrieve current user data'}
             
         return Response({
             'message': 'Top users retrieved successfully',
-            'data': response_data
-        }, status=status.HTTP_200_OK)
+            'data': response_data        }, status=status.HTTP_200_OK)
     except Exception as e:
         return Response({
             'error': str(e)


### PR DESCRIPTION
# Description
I have modified the leaderboard endpoint to return the current user too. New unit tests are added also.

### How to Check

- Clone the **feature/display-current-user-in-leaderboard** branch.

- Remove old containers from docker.
```
docker compose down -v
```

- Rebuild the containers from scratch
```
docker compose up --build
```

- Create another terminal and apply migrations

```
docker compose exec web python manage.py migrate
```

- Run tests
```
docker compose exec web python manage.py test
```

- Further tests can be done manually with using 3rd party applications like Insomnia or Postman

Closes #229 