### PR TITLE
Mobile: 2-method waste input , filtering and additional wastes  with chart fix

### DIFF
--- a/application/mobile/src/components/WasteFilterModal.tsx
+++ b/application/mobile/src/components/WasteFilterModal.tsx
@@ -1,0 +1,453 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  TouchableOpacity,
+  ScrollView,
+  Platform,
+} from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+import { useTranslation } from 'react-i18next';
+import { spacing, typography } from '../utils/theme';
+import { MIN_TOUCH_TARGET } from '../utils/accessibility';
+import { useRTL } from '../hooks/useRTL';
+
+// Time range options
+export type TimeRange = 'day' | 'week' | 'month' | 'year' | 'all' | 'custom';
+
+// All available waste types
+export const WASTE_TYPE_OPTIONS = [
+  'PLASTIC',
+  'PAPER',
+  'GLASS',
+  'METAL',
+  'ELECTRONIC',
+  'OIL&FATS',
+  'ORGANIC',
+] as const;
+
+export type WasteType = typeof WASTE_TYPE_OPTIONS[number];
+
+export interface WasteFilters {
+  timeRange: TimeRange;
+  customStartDate?: Date;
+  customEndDate?: Date;
+  wasteTypes: WasteType[];
+}
+
+interface WasteFilterModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onApply: (filters: WasteFilters) => void;
+  currentFilters: WasteFilters;
+}
+
+export const getDefaultFilters = (): WasteFilters => ({
+  timeRange: 'all',
+  wasteTypes: [...WASTE_TYPE_OPTIONS],
+});
+
+export const WasteFilterModal: React.FC<WasteFilterModalProps> = ({
+  visible,
+  onClose,
+  onApply,
+  currentFilters,
+}) => {
+  const { t } = useTranslation();
+  const { colors, isDarkMode } = useTheme();
+  const { textStyle, rowStyle } = useRTL();
+
+  // Local state for filters (applied on confirm)
+  const [timeRange, setTimeRange] = useState<TimeRange>(currentFilters.timeRange);
+  const [selectedWasteTypes, setSelectedWasteTypes] = useState<WasteType[]>(currentFilters.wasteTypes);
+  const [customStartDate, setCustomStartDate] = useState<Date | undefined>(currentFilters.customStartDate);
+  const [customEndDate, setCustomEndDate] = useState<Date | undefined>(currentFilters.customEndDate);
+
+  // Reset local state when modal opens
+  useEffect(() => {
+    if (visible) {
+      setTimeRange(currentFilters.timeRange);
+      setSelectedWasteTypes(currentFilters.wasteTypes);
+      setCustomStartDate(currentFilters.customStartDate);
+      setCustomEndDate(currentFilters.customEndDate);
+    }
+  }, [visible, currentFilters]);
+
+  // Time range options with translations
+  const TIME_RANGE_OPTIONS: { key: TimeRange; labelKey: string }[] = [
+    { key: 'day', labelKey: 'filter.timeRanges.day' },
+    { key: 'week', labelKey: 'filter.timeRanges.week' },
+    { key: 'month', labelKey: 'filter.timeRanges.month' },
+    { key: 'year', labelKey: 'filter.timeRanges.year' },
+    { key: 'all', labelKey: 'filter.timeRanges.all' },
+  ];
+
+  // Toggle waste type selection
+  const toggleWasteType = (wasteType: WasteType) => {
+    setSelectedWasteTypes((prev) => {
+      if (prev.includes(wasteType)) {
+        // Don't allow deselecting all types
+        if (prev.length === 1) return prev;
+        return prev.filter((t) => t !== wasteType);
+      } else {
+        return [...prev, wasteType];
+      }
+    });
+  };
+
+  // Select/Deselect all waste types
+  const toggleAllWasteTypes = () => {
+    if (selectedWasteTypes.length === WASTE_TYPE_OPTIONS.length) {
+      // Deselect all except first one (must have at least one)
+      setSelectedWasteTypes([WASTE_TYPE_OPTIONS[0]]);
+    } else {
+      setSelectedWasteTypes([...WASTE_TYPE_OPTIONS]);
+    }
+  };
+
+  // Apply filters
+  const handleApply = () => {
+    onApply({
+      timeRange,
+      wasteTypes: selectedWasteTypes,
+      customStartDate,
+      customEndDate,
+    });
+    onClose();
+  };
+
+  // Clear filters (reset to defaults)
+  const handleClear = () => {
+    const defaults = getDefaultFilters();
+    setTimeRange(defaults.timeRange);
+    setSelectedWasteTypes(defaults.wasteTypes);
+    setCustomStartDate(undefined);
+    setCustomEndDate(undefined);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={[styles.modalContent, { backgroundColor: colors.background }]}>
+          {/* Header */}
+          <View style={[styles.modalHeader, rowStyle]}>
+            <Text style={[styles.modalTitle, textStyle, { color: colors.primary }]}>
+              {t('filter.title')}
+            </Text>
+            <TouchableOpacity
+              onPress={handleClear}
+              style={styles.clearButton}
+              accessibilityLabel={t('filter.clearAll')}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.clearButtonText, { color: colors.error }]}>
+                {t('filter.clearAll')}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView 
+            style={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Time Range Section */}
+            <View style={styles.section}>
+              <Text style={[styles.sectionTitle, textStyle, { color: colors.textPrimary }]}>
+                {t('filter.timeRange')}
+              </Text>
+              <View style={styles.optionsContainer}>
+                {TIME_RANGE_OPTIONS.map((option) => (
+                  <TouchableOpacity
+                    key={option.key}
+                    style={[
+                      styles.optionChip,
+                      { 
+                        backgroundColor: timeRange === option.key 
+                          ? colors.primary 
+                          : colors.backgroundSecondary,
+                        borderColor: timeRange === option.key 
+                          ? colors.primary 
+                          : colors.lightGray,
+                      },
+                    ]}
+                    onPress={() => setTimeRange(option.key)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected: timeRange === option.key }}
+                  >
+                    <Text
+                      style={[
+                        styles.optionChipText,
+                        {
+                          color: timeRange === option.key
+                            ? colors.textOnPrimary
+                            : colors.textPrimary,
+                        },
+                      ]}
+                    >
+                      {t(option.labelKey)}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+
+            {/* Waste Types Section */}
+            <View style={styles.section}>
+              <View style={[styles.sectionHeader, rowStyle]}>
+                <Text style={[styles.sectionTitle, textStyle, { color: colors.textPrimary }]}>
+                  {t('filter.wasteTypes')}
+                </Text>
+                <TouchableOpacity
+                  onPress={toggleAllWasteTypes}
+                  style={styles.selectAllButton}
+                  accessibilityLabel={
+                    selectedWasteTypes.length === WASTE_TYPE_OPTIONS.length
+                      ? t('filter.deselectAll')
+                      : t('filter.selectAll')
+                  }
+                  accessibilityRole="button"
+                >
+                  <Text style={[styles.selectAllText, { color: colors.primary }]}>
+                    {selectedWasteTypes.length === WASTE_TYPE_OPTIONS.length
+                      ? t('filter.deselectAll')
+                      : t('filter.selectAll')}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View style={styles.wasteTypesGrid}>
+                {WASTE_TYPE_OPTIONS.map((wasteType) => {
+                  const isSelected = selectedWasteTypes.includes(wasteType);
+                  return (
+                    <TouchableOpacity
+                      key={wasteType}
+                      style={[
+                        styles.wasteTypeChip,
+                        {
+                          backgroundColor: isSelected
+                            ? colors.primary
+                            : colors.backgroundSecondary,
+                          borderColor: isSelected
+                            ? colors.primary
+                            : colors.lightGray,
+                        },
+                      ]}
+                      onPress={() => toggleWasteType(wasteType)}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: isSelected }}
+                      accessibilityLabel={t(`home.wasteTypes.${wasteType}`)}
+                    >
+                      <Text
+                        style={[
+                          styles.wasteTypeText,
+                          {
+                            color: isSelected
+                              ? colors.textOnPrimary
+                              : colors.textPrimary,
+                          },
+                        ]}
+                      >
+                        {t(`home.wasteTypes.${wasteType}`)}
+                      </Text>
+                      {isSelected && (
+                        <Text style={[styles.checkmark, { color: colors.textOnPrimary }]}>
+                          ✓
+                        </Text>
+                      )}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+
+            {/* Selected filters summary */}
+            <View style={[styles.summarySection, { backgroundColor: colors.backgroundSecondary }]}>
+              <Text style={[styles.summaryTitle, textStyle, { color: colors.textSecondary }]}>
+                {t('filter.selectedFilters')}
+              </Text>
+              <Text style={[styles.summaryText, textStyle, { color: colors.textPrimary }]}>
+                {t('filter.timeRange')}: {t(`filter.timeRanges.${timeRange}`)}
+              </Text>
+              <Text style={[styles.summaryText, textStyle, { color: colors.textPrimary }]}>
+                {t('filter.wasteTypes')}: {selectedWasteTypes.length}/{WASTE_TYPE_OPTIONS.length} {t('filter.selected')}
+              </Text>
+            </View>
+          </ScrollView>
+
+          {/* Footer buttons */}
+          <View style={styles.footerButtons}>
+            <TouchableOpacity
+              style={[styles.cancelButton, { backgroundColor: colors.lightGray }]}
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel={t('common.cancel')}
+            >
+              <Text style={[styles.cancelButtonText, { color: colors.textPrimary }]}>
+                {t('common.cancel')}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.applyButton, { backgroundColor: colors.primary }]}
+              onPress={handleApply}
+              accessibilityRole="button"
+              accessibilityLabel={t('filter.apply')}
+            >
+              <Text style={[styles.applyButtonText, { color: colors.textOnPrimary }]}>
+                {t('filter.apply')}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingTop: spacing.lg,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: Platform.OS === 'ios' ? spacing.xl + 20 : spacing.lg,
+    maxHeight: '85%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  modalTitle: {
+    ...typography.h2,
+  },
+  clearButton: {
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+  },
+  clearButtonText: {
+    ...typography.body,
+    fontWeight: '600',
+  },
+  scrollContent: {
+    flexGrow: 0,
+  },
+  section: {
+    marginBottom: spacing.lg,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    marginBottom: spacing.sm,
+  },
+  selectAllButton: {
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+  },
+  selectAllText: {
+    ...typography.caption,
+    fontWeight: '600',
+  },
+  optionsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  optionChip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+    borderWidth: 1,
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  optionChipText: {
+    ...typography.body,
+    fontWeight: '500',
+  },
+  wasteTypesGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  wasteTypeChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 12,
+    borderWidth: 1,
+    minHeight: MIN_TOUCH_TARGET,
+  },
+  wasteTypeText: {
+    ...typography.body,
+    fontWeight: '500',
+  },
+  checkmark: {
+    marginLeft: spacing.xs,
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  summarySection: {
+    padding: spacing.md,
+    borderRadius: 12,
+    marginBottom: spacing.md,
+  },
+  summaryTitle: {
+    ...typography.caption,
+    marginBottom: spacing.xs,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  summaryText: {
+    ...typography.body,
+    marginBottom: spacing.xs,
+  },
+  footerButtons: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: spacing.md,
+  },
+  cancelButton: {
+    flex: 1,
+    minHeight: MIN_TOUCH_TARGET,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cancelButtonText: {
+    ...typography.button,
+  },
+  applyButton: {
+    flex: 2,
+    minHeight: MIN_TOUCH_TARGET,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  applyButtonText: {
+    ...typography.button,
+  },
+});
+
+export default WasteFilterModal;
+

--- a/application/mobile/src/components/__tests__/WasteFilterModal.test.tsx
+++ b/application/mobile/src/components/__tests__/WasteFilterModal.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { WasteFilterModal, getDefaultFilters, WASTE_TYPE_OPTIONS, WasteFilters } from '../WasteFilterModal';
+
+// Mock dependencies
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'filter.title': 'Filter Data',
+        'filter.timeRange': 'Time Range',
+        'filter.wasteTypes': 'Waste Types',
+        'filter.apply': 'Apply Filters',
+        'filter.clearAll': 'Clear All',
+        'filter.selectAll': 'Select All',
+        'filter.deselectAll': 'Deselect All',
+        'filter.selected': 'selected',
+        'filter.selectedFilters': 'Selected Filters',
+        'filter.timeRanges.day': 'Today',
+        'filter.timeRanges.week': 'Last 7 Days',
+        'filter.timeRanges.month': 'Last 30 Days',
+        'filter.timeRanges.year': 'Last Year',
+        'filter.timeRanges.all': 'All Time',
+        'common.cancel': 'Cancel',
+        'home.wasteTypes.PLASTIC': 'Plastic',
+        'home.wasteTypes.PAPER': 'Paper',
+        'home.wasteTypes.GLASS': 'Glass',
+        'home.wasteTypes.METAL': 'Metal',
+        'home.wasteTypes.ELECTRONIC': 'Electronic',
+        'home.wasteTypes.OIL&FATS': 'Oil',
+        'home.wasteTypes.ORGANIC': 'Organic',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock('../../context/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#2E7D32',
+      background: '#FFFFFF',
+      backgroundSecondary: '#F5F5F5',
+      textPrimary: '#212121',
+      textSecondary: '#616161',
+      textOnPrimary: '#FFFFFF',
+      lightGray: '#E0E0E0',
+      error: '#C62828',
+    },
+    isDarkMode: false,
+  }),
+}));
+
+jest.mock('../../hooks/useRTL', () => ({
+  useRTL: () => ({
+    isRTL: false,
+    textStyle: {},
+    rowStyle: {},
+  }),
+}));
+
+describe('WasteFilterModal', () => {
+  const defaultProps = {
+    visible: true,
+    onClose: jest.fn(),
+    onApply: jest.fn(),
+    currentFilters: getDefaultFilters(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly when visible', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    expect(getByText('Filter Data')).toBeTruthy();
+    expect(getByText('Time Range')).toBeTruthy();
+    expect(getByText('Waste Types')).toBeTruthy();
+  });
+
+  it('should not render when not visible', () => {
+    const { queryByText } = render(
+      <WasteFilterModal {...defaultProps} visible={false} />
+    );
+    
+    // Modal should not be visible (content may still be in tree but not displayed)
+    // In React Native, we can check if the modal's visible prop is false
+  });
+
+  it('should display all time range options', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    expect(getByText('Today')).toBeTruthy();
+    expect(getByText('Last 7 Days')).toBeTruthy();
+    expect(getByText('Last 30 Days')).toBeTruthy();
+    expect(getByText('Last Year')).toBeTruthy();
+    expect(getByText('All Time')).toBeTruthy();
+  });
+
+  it('should display all waste type options', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    expect(getByText('Plastic')).toBeTruthy();
+    expect(getByText('Paper')).toBeTruthy();
+    expect(getByText('Glass')).toBeTruthy();
+    expect(getByText('Metal')).toBeTruthy();
+    expect(getByText('Electronic')).toBeTruthy();
+    expect(getByText('Oil')).toBeTruthy();
+    expect(getByText('Organic')).toBeTruthy();
+  });
+
+  it('should call onClose when cancel button is pressed', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    fireEvent.press(getByText('Cancel'));
+    
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('should call onApply with filters when apply button is pressed', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    fireEvent.press(getByText('Apply Filters'));
+    
+    expect(defaultProps.onApply).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('should update time range when option is selected', () => {
+    const onApply = jest.fn();
+    const { getByText } = render(
+      <WasteFilterModal {...defaultProps} onApply={onApply} />
+    );
+    
+    // Select "Last 7 Days"
+    fireEvent.press(getByText('Last 7 Days'));
+    
+    // Apply filters
+    fireEvent.press(getByText('Apply Filters'));
+    
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeRange: 'week',
+      })
+    );
+  });
+
+  it('should toggle waste type selection', () => {
+    const onApply = jest.fn();
+    const { getByText } = render(
+      <WasteFilterModal {...defaultProps} onApply={onApply} />
+    );
+    
+    // Deselect Plastic (should still work since we have more types selected)
+    fireEvent.press(getByText('Plastic'));
+    
+    // Apply filters
+    fireEvent.press(getByText('Apply Filters'));
+    
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wasteTypes: expect.not.arrayContaining(['PLASTIC']),
+      })
+    );
+  });
+
+  it('should not allow deselecting all waste types', () => {
+    const onApply = jest.fn();
+    // Start with only one waste type selected
+    const currentFilters: WasteFilters = {
+      timeRange: 'all',
+      wasteTypes: ['PLASTIC'],
+    };
+    
+    const { getByText } = render(
+      <WasteFilterModal {...defaultProps} currentFilters={currentFilters} onApply={onApply} />
+    );
+    
+    // Try to deselect Plastic (should not work since it's the only one)
+    fireEvent.press(getByText('Plastic'));
+    
+    // Apply filters
+    fireEvent.press(getByText('Apply Filters'));
+    
+    // Should still have PLASTIC selected
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wasteTypes: ['PLASTIC'],
+      })
+    );
+  });
+
+  it('should display selected filters summary', () => {
+    const { getByText } = render(<WasteFilterModal {...defaultProps} />);
+    
+    expect(getByText('Selected Filters')).toBeTruthy();
+  });
+});
+
+describe('getDefaultFilters', () => {
+  it('should return correct default values', () => {
+    const defaults = getDefaultFilters();
+    
+    expect(defaults.timeRange).toBe('all');
+    expect(defaults.wasteTypes).toEqual([...WASTE_TYPE_OPTIONS]);
+    expect(defaults.customStartDate).toBeUndefined();
+    expect(defaults.customEndDate).toBeUndefined();
+  });
+});
+
+describe('WASTE_TYPE_OPTIONS', () => {
+  it('should contain all expected waste types', () => {
+    expect(WASTE_TYPE_OPTIONS).toContain('PLASTIC');
+    expect(WASTE_TYPE_OPTIONS).toContain('PAPER');
+    expect(WASTE_TYPE_OPTIONS).toContain('GLASS');
+    expect(WASTE_TYPE_OPTIONS).toContain('METAL');
+    expect(WASTE_TYPE_OPTIONS).toContain('ELECTRONIC');
+    expect(WASTE_TYPE_OPTIONS).toContain('OIL&FATS');
+    expect(WASTE_TYPE_OPTIONS).toContain('ORGANIC');
+    expect(WASTE_TYPE_OPTIONS.length).toBe(7);
+  });
+});
+

--- a/application/mobile/src/hooks/__tests__/useWasteFilters.test.ts
+++ b/application/mobile/src/hooks/__tests__/useWasteFilters.test.ts
@@ -1,0 +1,257 @@
+import {
+  getStartDateForRange,
+  filterRecordsByDate,
+  filterWasteData,
+  hasActiveFilters,
+  WasteDataItem,
+  WasteRecord,
+} from '../useWasteFilters';
+import { WasteFilters, getDefaultFilters, WASTE_TYPE_OPTIONS } from '../../components/WasteFilterModal';
+
+describe('useWasteFilters', () => {
+  // Mock data for testing
+  const mockRecords: WasteRecord[] = [
+    { id: 1, type: 'PLASTIC', amount: 2.5, date: new Date().toISOString() }, // Today
+    { id: 2, type: 'PLASTIC', amount: 1.5, date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() }, // 3 days ago
+    { id: 3, type: 'PLASTIC', amount: 3.0, date: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString() }, // 10 days ago
+    { id: 4, type: 'PLASTIC', amount: 2.0, date: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString() }, // 45 days ago
+    { id: 5, type: 'PLASTIC', amount: 5.0, date: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString() }, // Over a year ago
+  ];
+
+  const mockWasteData: WasteDataItem[] = [
+    {
+      waste_type: 'PLASTIC',
+      total_amount: 14.0,
+      records: mockRecords,
+    },
+    {
+      waste_type: 'PAPER',
+      total_amount: 5.0,
+      records: [
+        { id: 6, type: 'PAPER', amount: 5.0, date: new Date().toISOString() },
+      ],
+    },
+    {
+      waste_type: 'GLASS',
+      total_amount: 3.0,
+      records: [
+        { id: 7, type: 'GLASS', amount: 3.0, date: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString() },
+      ],
+    },
+  ];
+
+  describe('getStartDateForRange', () => {
+    it('should return null for "all" time range', () => {
+      const result = getStartDateForRange('all');
+      expect(result).toBeNull();
+    });
+
+    it('should return start of today for "day" time range', () => {
+      const result = getStartDateForRange('day');
+      expect(result).not.toBeNull();
+      
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      expect(result!.getTime()).toBe(now.getTime());
+    });
+
+    it('should return 7 days ago for "week" time range', () => {
+      const result = getStartDateForRange('week');
+      expect(result).not.toBeNull();
+      
+      const weekAgo = new Date();
+      weekAgo.setDate(weekAgo.getDate() - 7);
+      weekAgo.setHours(0, 0, 0, 0);
+      expect(result!.getTime()).toBe(weekAgo.getTime());
+    });
+
+    it('should return 30 days ago for "month" time range', () => {
+      const result = getStartDateForRange('month');
+      expect(result).not.toBeNull();
+      
+      const monthAgo = new Date();
+      monthAgo.setMonth(monthAgo.getMonth() - 1);
+      monthAgo.setHours(0, 0, 0, 0);
+      expect(result!.getTime()).toBe(monthAgo.getTime());
+    });
+
+    it('should return 1 year ago for "year" time range', () => {
+      const result = getStartDateForRange('year');
+      expect(result).not.toBeNull();
+      
+      const yearAgo = new Date();
+      yearAgo.setFullYear(yearAgo.getFullYear() - 1);
+      yearAgo.setHours(0, 0, 0, 0);
+      expect(result!.getTime()).toBe(yearAgo.getTime());
+    });
+  });
+
+  describe('filterRecordsByDate', () => {
+    it('should return all records when no date filters are provided', () => {
+      const result = filterRecordsByDate(mockRecords, null, null);
+      expect(result.length).toBe(mockRecords.length);
+    });
+
+    it('should filter records after start date', () => {
+      const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+      const result = filterRecordsByDate(mockRecords, startDate, null);
+      
+      // Should include records from today and 3 days ago
+      expect(result.length).toBe(2);
+      expect(result.map(r => r.id)).toContain(1);
+      expect(result.map(r => r.id)).toContain(2);
+    });
+
+    it('should filter records before end date', () => {
+      const endDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000); // 5 days ago
+      const result = filterRecordsByDate(mockRecords, null, endDate);
+      
+      // Should include records from 10 days, 45 days, and over a year ago
+      expect(result.length).toBe(3);
+      expect(result.map(r => r.id)).toContain(3);
+      expect(result.map(r => r.id)).toContain(4);
+      expect(result.map(r => r.id)).toContain(5);
+    });
+
+    it('should filter records between start and end dates', () => {
+      const startDate = new Date(Date.now() - 50 * 24 * 60 * 60 * 1000); // 50 days ago
+      const endDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000); // 5 days ago
+      const result = filterRecordsByDate(mockRecords, startDate, endDate);
+      
+      // Should include records from 10 days and 45 days ago
+      expect(result.length).toBe(2);
+      expect(result.map(r => r.id)).toContain(3);
+      expect(result.map(r => r.id)).toContain(4);
+    });
+  });
+
+  describe('filterWasteData', () => {
+    it('should return all data with default filters', () => {
+      const filters = getDefaultFilters();
+      const result = filterWasteData(mockWasteData, filters);
+      
+      expect(result.length).toBe(mockWasteData.length);
+    });
+
+    it('should filter by waste types', () => {
+      const filters: WasteFilters = {
+        timeRange: 'all',
+        wasteTypes: ['PLASTIC', 'PAPER'],
+      };
+      const result = filterWasteData(mockWasteData, filters);
+      
+      expect(result.length).toBe(2);
+      expect(result.map(r => r.waste_type)).toContain('PLASTIC');
+      expect(result.map(r => r.waste_type)).toContain('PAPER');
+      expect(result.map(r => r.waste_type)).not.toContain('GLASS');
+    });
+
+    it('should filter by time range and recalculate totals', () => {
+      const filters: WasteFilters = {
+        timeRange: 'week',
+        wasteTypes: [...WASTE_TYPE_OPTIONS],
+      };
+      const result = filterWasteData(mockWasteData, filters);
+      
+      // PLASTIC should only have records from today and 3 days ago
+      const plastic = result.find(r => r.waste_type === 'PLASTIC');
+      expect(plastic).toBeDefined();
+      expect(plastic!.records.length).toBe(2);
+      expect(plastic!.total_amount).toBe(4.0); // 2.5 + 1.5
+      
+      // PAPER should have today's record
+      const paper = result.find(r => r.waste_type === 'PAPER');
+      expect(paper).toBeDefined();
+      expect(paper!.records.length).toBe(1);
+      expect(paper!.total_amount).toBe(5.0);
+      
+      // GLASS should have no records (20 days ago is outside week)
+      const glass = result.find(r => r.waste_type === 'GLASS');
+      expect(glass).toBeDefined();
+      expect(glass!.records.length).toBe(0);
+      expect(glass!.total_amount).toBe(0);
+    });
+
+    it('should combine waste type and time range filters', () => {
+      const filters: WasteFilters = {
+        timeRange: 'month',
+        wasteTypes: ['PLASTIC', 'GLASS'],
+      };
+      const result = filterWasteData(mockWasteData, filters);
+      
+      expect(result.length).toBe(2);
+      
+      // PLASTIC should have records from today, 3 days ago, and 10 days ago
+      const plastic = result.find(r => r.waste_type === 'PLASTIC');
+      expect(plastic!.records.length).toBe(3);
+      expect(plastic!.total_amount).toBe(7.0); // 2.5 + 1.5 + 3.0
+      
+      // GLASS should have its record (20 days ago is within month)
+      const glass = result.find(r => r.waste_type === 'GLASS');
+      expect(glass!.records.length).toBe(1);
+      expect(glass!.total_amount).toBe(3.0);
+    });
+
+    it('should handle empty waste types array by returning empty results', () => {
+      const filters: WasteFilters = {
+        timeRange: 'all',
+        wasteTypes: [],
+      };
+      const result = filterWasteData(mockWasteData, filters);
+      
+      expect(result.length).toBe(0);
+    });
+  });
+
+  describe('hasActiveFilters', () => {
+    it('should return false for default filters', () => {
+      const filters = getDefaultFilters();
+      expect(hasActiveFilters(filters)).toBe(false);
+    });
+
+    it('should return true when time range is changed', () => {
+      const filters: WasteFilters = {
+        timeRange: 'week',
+        wasteTypes: [...WASTE_TYPE_OPTIONS],
+      };
+      expect(hasActiveFilters(filters)).toBe(true);
+    });
+
+    it('should return true when waste types are reduced', () => {
+      const filters: WasteFilters = {
+        timeRange: 'all',
+        wasteTypes: ['PLASTIC', 'PAPER'],
+      };
+      expect(hasActiveFilters(filters)).toBe(true);
+    });
+
+    it('should return true when both time range and waste types are changed', () => {
+      const filters: WasteFilters = {
+        timeRange: 'month',
+        wasteTypes: ['PLASTIC'],
+      };
+      expect(hasActiveFilters(filters)).toBe(true);
+    });
+
+    it('should return false when waste types are same but in different order', () => {
+      const filters: WasteFilters = {
+        timeRange: 'all',
+        wasteTypes: [...WASTE_TYPE_OPTIONS].reverse(),
+      };
+      // Since we sort before comparing, order shouldn't matter
+      expect(hasActiveFilters(filters)).toBe(false);
+    });
+  });
+
+  describe('getDefaultFilters', () => {
+    it('should return default filter values', () => {
+      const defaults = getDefaultFilters();
+      
+      expect(defaults.timeRange).toBe('all');
+      expect(defaults.wasteTypes).toEqual(WASTE_TYPE_OPTIONS);
+      expect(defaults.customStartDate).toBeUndefined();
+      expect(defaults.customEndDate).toBeUndefined();
+    });
+  });
+});
+

--- a/application/mobile/src/hooks/useWasteFilters.ts
+++ b/application/mobile/src/hooks/useWasteFilters.ts
@@ -1,0 +1,216 @@
+import { useState, useMemo, useCallback } from 'react';
+import { WasteFilters, TimeRange, WasteType, getDefaultFilters, WASTE_TYPE_OPTIONS } from '../components/WasteFilterModal';
+
+// Individual waste record type (from API)
+export interface WasteRecord {
+  id: number;
+  type: string;
+  amount: number;
+  date: string; // ISO date string
+}
+
+// Waste data grouped by type (from API)
+export interface WasteDataItem {
+  waste_type: string;
+  total_amount: number;
+  records: WasteRecord[];
+}
+
+// Filtered result for charts
+export interface FilteredWasteData {
+  waste_type: string;
+  total_amount: number;
+  records: WasteRecord[];
+}
+
+/**
+ * Get the start date for a given time range
+ */
+export const getStartDateForRange = (range: TimeRange): Date | null => {
+  const now = new Date();
+  
+  switch (range) {
+    case 'day':
+      const dayStart = new Date(now);
+      dayStart.setHours(0, 0, 0, 0);
+      return dayStart;
+    
+    case 'week':
+      const weekStart = new Date(now);
+      weekStart.setDate(now.getDate() - 7);
+      weekStart.setHours(0, 0, 0, 0);
+      return weekStart;
+    
+    case 'month':
+      const monthStart = new Date(now);
+      monthStart.setMonth(now.getMonth() - 1);
+      monthStart.setHours(0, 0, 0, 0);
+      return monthStart;
+    
+    case 'year':
+      const yearStart = new Date(now);
+      yearStart.setFullYear(now.getFullYear() - 1);
+      yearStart.setHours(0, 0, 0, 0);
+      return yearStart;
+    
+    case 'all':
+    default:
+      return null; // No time filtering
+  }
+};
+
+/**
+ * Filter waste records by date range
+ */
+export const filterRecordsByDate = (
+  records: WasteRecord[],
+  startDate: Date | null,
+  endDate?: Date | null
+): WasteRecord[] => {
+  if (!startDate && !endDate) {
+    return records;
+  }
+
+  return records.filter((record) => {
+    const recordDate = new Date(record.date);
+    
+    if (startDate && recordDate < startDate) {
+      return false;
+    }
+    
+    if (endDate && recordDate > endDate) {
+      return false;
+    }
+    
+    return true;
+  });
+};
+
+/**
+ * Filter waste data by waste types and time range
+ */
+export const filterWasteData = (
+  data: WasteDataItem[],
+  filters: WasteFilters
+): FilteredWasteData[] => {
+  // Get date range
+  const startDate = filters.timeRange === 'custom' 
+    ? filters.customStartDate || null
+    : getStartDateForRange(filters.timeRange);
+  
+  const endDate = filters.timeRange === 'custom'
+    ? filters.customEndDate || null
+    : null;
+
+  // Filter by waste types
+  const filteredByType = data.filter((item) => 
+    filters.wasteTypes.includes(item.waste_type as WasteType)
+  );
+
+  // Filter records by date and recalculate totals
+  return filteredByType.map((item) => {
+    const filteredRecords = filterRecordsByDate(item.records, startDate, endDate);
+    const totalAmount = filteredRecords.reduce((sum, record) => sum + record.amount, 0);
+
+    return {
+      waste_type: item.waste_type,
+      total_amount: totalAmount,
+      records: filteredRecords,
+    };
+  });
+};
+
+/**
+ * Check if any filters are active (different from defaults)
+ */
+export const hasActiveFilters = (filters: WasteFilters): boolean => {
+  const defaults = getDefaultFilters();
+  
+  // Check time range
+  if (filters.timeRange !== defaults.timeRange) {
+    return true;
+  }
+  
+  // Check waste types (compare sorted arrays)
+  const sortedFilters = [...filters.wasteTypes].sort();
+  const sortedDefaults = [...defaults.wasteTypes].sort();
+  
+  if (sortedFilters.length !== sortedDefaults.length) {
+    return true;
+  }
+  
+  for (let i = 0; i < sortedFilters.length; i++) {
+    if (sortedFilters[i] !== sortedDefaults[i]) {
+      return true;
+    }
+  }
+  
+  return false;
+};
+
+/**
+ * Custom hook for managing waste filters and filtered data
+ */
+export const useWasteFilters = (wasteData: WasteDataItem[]) => {
+  const [filters, setFilters] = useState<WasteFilters>(getDefaultFilters());
+  const [isFilterModalVisible, setIsFilterModalVisible] = useState(false);
+
+  // Memoized filtered data
+  const filteredData = useMemo(() => {
+    return filterWasteData(wasteData, filters);
+  }, [wasteData, filters]);
+
+  // Check if filters are active
+  const filtersActive = useMemo(() => {
+    return hasActiveFilters(filters);
+  }, [filters]);
+
+  // Get total filtered amount
+  const totalFilteredAmount = useMemo(() => {
+    return filteredData.reduce((sum, item) => sum + item.total_amount, 0);
+  }, [filteredData]);
+
+  // Get count of filtered records
+  const totalFilteredRecords = useMemo(() => {
+    return filteredData.reduce((sum, item) => sum + item.records.length, 0);
+  }, [filteredData]);
+
+  // Callbacks
+  const openFilterModal = useCallback(() => {
+    setIsFilterModalVisible(true);
+  }, []);
+
+  const closeFilterModal = useCallback(() => {
+    setIsFilterModalVisible(false);
+  }, []);
+
+  const applyFilters = useCallback((newFilters: WasteFilters) => {
+    setFilters(newFilters);
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    setFilters(getDefaultFilters());
+  }, []);
+
+  return {
+    // State
+    filters,
+    filteredData,
+    filtersActive,
+    isFilterModalVisible,
+    
+    // Computed values
+    totalFilteredAmount,
+    totalFilteredRecords,
+    
+    // Actions
+    openFilterModal,
+    closeFilterModal,
+    applyFilters,
+    resetFilters,
+    setFilters,
+  };
+};
+
+export default useWasteFilters;
+

--- a/application/mobile/src/i18n/locales/ar.json
+++ b/application/mobile/src/i18n/locales/ar.json
@@ -161,5 +161,60 @@
     "approve": "موافقة",
     "reject": "رفض",
     "ban": "حظر المستخدم"
+  },
+  "wasteHelper": {
+    "selectMethod": "اختر الطريقة",
+    "selectTypeAndMethod": "يرجى اختيار نوع النفايات وطريقة الإدخال",
+    "enterValidQuantity": "يرجى إدخال كمية صالحة (رقم موجب)",
+    "selectUnitAndCount": "يرجى اختيار نوع العنصر والعدد",
+    "highAmountWarning": "هذه الكمية تبدو مرتفعة. هل أنت متأكد من صحتها؟",
+    "excessiveAmountError": "الكمية تتجاوز الحد الأقصى (5000 جرام). يرجى إدخال كمية أصغر.",
+    "quantityGrams": "جرام",
+    "chooseItem": "اختر عنصراً",
+    "count": "العدد",
+    "methods": {
+      "grams": "بالجرام",
+      "unit": "بالعنصر"
+    },
+    "items": {
+      "plasticBottle": "زجاجة بلاستيكية",
+      "plasticBag": "كيس بلاستيك",
+      "plasticCup": "كوب بلاستيك",
+      "paperSheet": "ورقة (A4)",
+      "notebook": "دفتر",
+      "glassBottle": "زجاجة زجاجية",
+      "glassJar": "برطمان زجاجي",
+      "aluminumCan": "علبة ألومنيوم",
+      "metalSpoon": "ملعقة معدنية",
+      "phoneCharger": "شاحن هاتف",
+      "usbCable": "كابل USB",
+      "cookingOil": "زيت طهي (ملعقة)",
+      "butterWrapper": "غلاف زبدة",
+      "bananaPeel": "قشرة موز",
+      "appleCore": "قلب تفاحة",
+      "foodScraps": "بقايا طعام"
+    }
+  },
+  "filter": {
+    "title": "تصفية البيانات",
+    "timeRange": "النطاق الزمني",
+    "wasteTypes": "أنواع النفايات",
+    "apply": "تطبيق الفلاتر",
+    "clearAll": "مسح الكل",
+    "selectAll": "تحديد الكل",
+    "deselectAll": "إلغاء تحديد الكل",
+    "selected": "محدد",
+    "selectedFilters": "الفلاتر المحددة",
+    "noDataForFilters": "لا توجد بيانات للفلاتر المحددة",
+    "filterButton": "تصفية",
+    "activeFilters": "الفلاتر نشطة",
+    "timeRanges": {
+      "day": "اليوم",
+      "week": "آخر 7 أيام",
+      "month": "آخر 30 يوماً",
+      "year": "السنة الماضية",
+      "all": "كل الوقت",
+      "custom": "نطاق مخصص"
+    }
   }
 }

--- a/application/mobile/src/i18n/locales/en.json
+++ b/application/mobile/src/i18n/locales/en.json
@@ -161,6 +161,61 @@
     "approve": "Approve",
     "reject": "Reject",
     "ban": "Ban User"
+  },
+  "wasteHelper": {
+    "selectMethod": "Select Method",
+    "selectTypeAndMethod": "Please select a waste type and input method",
+    "enterValidQuantity": "Please enter a valid quantity (positive number)",
+    "selectUnitAndCount": "Please select an item type and count",
+    "highAmountWarning": "This amount seems high. Are you sure this is correct?",
+    "excessiveAmountError": "Amount exceeds maximum limit (5000g). Please enter a smaller amount.",
+    "quantityGrams": "Grams",
+    "chooseItem": "Choose Item",
+    "count": "Count",
+    "methods": {
+      "grams": "By Grams",
+      "unit": "By Item"
+    },
+    "items": {
+      "plasticBottle": "Plastic Bottle",
+      "plasticBag": "Plastic Bag",
+      "plasticCup": "Plastic Cup",
+      "paperSheet": "Paper Sheet (A4)",
+      "notebook": "Notebook",
+      "glassBottle": "Glass Bottle",
+      "glassJar": "Glass Jar",
+      "aluminumCan": "Aluminum Can",
+      "metalSpoon": "Metal Spoon",
+      "phoneCharger": "Phone Charger",
+      "usbCable": "USB Cable",
+      "cookingOil": "Cooking Oil (tbsp)",
+      "butterWrapper": "Butter Wrapper",
+      "bananaPeel": "Banana Peel",
+      "appleCore": "Apple Core",
+      "foodScraps": "Food Scraps"
+    }
+  },
+  "filter": {
+    "title": "Filter Data",
+    "timeRange": "Time Range",
+    "wasteTypes": "Waste Types",
+    "apply": "Apply Filters",
+    "clearAll": "Clear All",
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "selected": "selected",
+    "selectedFilters": "Selected Filters",
+    "noDataForFilters": "No data for selected filters",
+    "filterButton": "Filter",
+    "activeFilters": "Filters Active",
+    "timeRanges": {
+      "day": "Today",
+      "week": "Last 7 Days",
+      "month": "Last 30 Days",
+      "year": "Last Year",
+      "all": "All Time",
+      "custom": "Custom Range"
+    }
   }
 }
 

--- a/application/mobile/src/i18n/locales/es.json
+++ b/application/mobile/src/i18n/locales/es.json
@@ -161,6 +161,61 @@
     "approve": "Aprobar",
     "reject": "Rechazar",
     "ban": "Prohibir usuario"
+  },
+  "wasteHelper": {
+    "selectMethod": "Seleccionar método",
+    "selectTypeAndMethod": "Por favor seleccione un tipo de residuo y método de entrada",
+    "enterValidQuantity": "Por favor ingrese una cantidad válida (número positivo)",
+    "selectUnitAndCount": "Por favor seleccione un tipo de artículo y cantidad",
+    "highAmountWarning": "Esta cantidad parece alta. ¿Está seguro de que es correcta?",
+    "excessiveAmountError": "La cantidad excede el límite máximo (5000g). Por favor ingrese una cantidad menor.",
+    "quantityGrams": "Gramos",
+    "chooseItem": "Elegir artículo",
+    "count": "Cantidad",
+    "methods": {
+      "grams": "Por gramos",
+      "unit": "Por artículo"
+    },
+    "items": {
+      "plasticBottle": "Botella de plástico",
+      "plasticBag": "Bolsa de plástico",
+      "plasticCup": "Vaso de plástico",
+      "paperSheet": "Hoja de papel (A4)",
+      "notebook": "Cuaderno",
+      "glassBottle": "Botella de vidrio",
+      "glassJar": "Frasco de vidrio",
+      "aluminumCan": "Lata de aluminio",
+      "metalSpoon": "Cuchara de metal",
+      "phoneCharger": "Cargador de teléfono",
+      "usbCable": "Cable USB",
+      "cookingOil": "Aceite de cocina (cda)",
+      "butterWrapper": "Envoltorio de mantequilla",
+      "bananaPeel": "Cáscara de plátano",
+      "appleCore": "Corazón de manzana",
+      "foodScraps": "Restos de comida"
+    }
+  },
+  "filter": {
+    "title": "Filtrar datos",
+    "timeRange": "Rango de tiempo",
+    "wasteTypes": "Tipos de residuos",
+    "apply": "Aplicar filtros",
+    "clearAll": "Borrar todo",
+    "selectAll": "Seleccionar todo",
+    "deselectAll": "Deseleccionar todo",
+    "selected": "seleccionados",
+    "selectedFilters": "Filtros seleccionados",
+    "noDataForFilters": "No hay datos para los filtros seleccionados",
+    "filterButton": "Filtro",
+    "activeFilters": "Filtros activos",
+    "timeRanges": {
+      "day": "Hoy",
+      "week": "Últimos 7 días",
+      "month": "Últimos 30 días",
+      "year": "Último año",
+      "all": "Todo el tiempo",
+      "custom": "Rango personalizado"
+    }
   }
 }
 

--- a/application/mobile/src/i18n/locales/fr.json
+++ b/application/mobile/src/i18n/locales/fr.json
@@ -161,6 +161,61 @@
     "approve": "Approuver",
     "reject": "Rejeter",
     "ban": "Bannir l'utilisateur"
+  },
+  "wasteHelper": {
+    "selectMethod": "Sélectionner la méthode",
+    "selectTypeAndMethod": "Veuillez sélectionner un type de déchet et une méthode de saisie",
+    "enterValidQuantity": "Veuillez entrer une quantité valide (nombre positif)",
+    "selectUnitAndCount": "Veuillez sélectionner un type d'article et une quantité",
+    "highAmountWarning": "Cette quantité semble élevée. Êtes-vous sûr qu'elle est correcte ?",
+    "excessiveAmountError": "La quantité dépasse la limite maximale (5000g). Veuillez entrer une quantité plus petite.",
+    "quantityGrams": "Grammes",
+    "chooseItem": "Choisir un article",
+    "count": "Nombre",
+    "methods": {
+      "grams": "Par grammes",
+      "unit": "Par article"
+    },
+    "items": {
+      "plasticBottle": "Bouteille en plastique",
+      "plasticBag": "Sac en plastique",
+      "plasticCup": "Gobelet en plastique",
+      "paperSheet": "Feuille de papier (A4)",
+      "notebook": "Cahier",
+      "glassBottle": "Bouteille en verre",
+      "glassJar": "Bocal en verre",
+      "aluminumCan": "Canette en aluminium",
+      "metalSpoon": "Cuillère en métal",
+      "phoneCharger": "Chargeur de téléphone",
+      "usbCable": "Câble USB",
+      "cookingOil": "Huile de cuisson (cs)",
+      "butterWrapper": "Emballage de beurre",
+      "bananaPeel": "Peau de banane",
+      "appleCore": "Trognon de pomme",
+      "foodScraps": "Restes de nourriture"
+    }
+  },
+  "filter": {
+    "title": "Filtrer les données",
+    "timeRange": "Plage de temps",
+    "wasteTypes": "Types de déchets",
+    "apply": "Appliquer les filtres",
+    "clearAll": "Tout effacer",
+    "selectAll": "Tout sélectionner",
+    "deselectAll": "Tout désélectionner",
+    "selected": "sélectionnés",
+    "selectedFilters": "Filtres sélectionnés",
+    "noDataForFilters": "Aucune donnée pour les filtres sélectionnés",
+    "filterButton": "Filtrer",
+    "activeFilters": "Filtres actifs",
+    "timeRanges": {
+      "day": "Aujourd'hui",
+      "week": "7 derniers jours",
+      "month": "30 derniers jours",
+      "year": "Dernière année",
+      "all": "Tout le temps",
+      "custom": "Plage personnalisée"
+    }
   }
 }
 

--- a/application/mobile/src/i18n/locales/tr.json
+++ b/application/mobile/src/i18n/locales/tr.json
@@ -161,6 +161,61 @@
     "approve": "Onayla",
     "reject": "Reddet",
     "ban": "Kullanıcıyı Engelle"
+  },
+  "wasteHelper": {
+    "selectMethod": "Yöntem Seç",
+    "selectTypeAndMethod": "Lütfen atık türü ve giriş yöntemi seçin",
+    "enterValidQuantity": "Lütfen geçerli bir miktar girin (pozitif sayı)",
+    "selectUnitAndCount": "Lütfen öğe türü ve adet seçin",
+    "highAmountWarning": "Bu miktar yüksek görünüyor. Doğru olduğundan emin misiniz?",
+    "excessiveAmountError": "Miktar maksimum limiti aşıyor (5000g). Lütfen daha küçük bir miktar girin.",
+    "quantityGrams": "Gram",
+    "chooseItem": "Öğe Seç",
+    "count": "Adet",
+    "methods": {
+      "grams": "Gram ile",
+      "unit": "Öğe ile"
+    },
+    "items": {
+      "plasticBottle": "Plastik Şişe",
+      "plasticBag": "Plastik Poşet",
+      "plasticCup": "Plastik Bardak",
+      "paperSheet": "Kağıt (A4)",
+      "notebook": "Defter",
+      "glassBottle": "Cam Şişe",
+      "glassJar": "Cam Kavanoz",
+      "aluminumCan": "Alüminyum Kutu",
+      "metalSpoon": "Metal Kaşık",
+      "phoneCharger": "Telefon Şarj Cihazı",
+      "usbCable": "USB Kablo",
+      "cookingOil": "Yemeklik Yağ (kaşık)",
+      "butterWrapper": "Tereyağı Paketi",
+      "bananaPeel": "Muz Kabuğu",
+      "appleCore": "Elma Çekirdeği",
+      "foodScraps": "Yemek Artığı"
+    }
+  },
+  "filter": {
+    "title": "Veriyi Filtrele",
+    "timeRange": "Zaman Aralığı",
+    "wasteTypes": "Atık Türleri",
+    "apply": "Filtreleri Uygula",
+    "clearAll": "Temizle",
+    "selectAll": "Tümünü Seç",
+    "deselectAll": "Seçimi Kaldır",
+    "selected": "seçili",
+    "selectedFilters": "Seçili Filtreler",
+    "noDataForFilters": "Seçili filtreler için veri yok",
+    "filterButton": "Filtre",
+    "activeFilters": "Filtreler Aktif",
+    "timeRanges": {
+      "day": "Bugün",
+      "week": "Son 7 Gün",
+      "month": "Son 30 Gün",
+      "year": "Son Yıl",
+      "all": "Tüm Zamanlar",
+      "custom": "Özel Aralık"
+    }
   }
 }
 

--- a/application/mobile/src/screens/HomeScreen.tsx
+++ b/application/mobile/src/screens/HomeScreen.tsx
@@ -11,6 +11,10 @@ import {
   RefreshControl,
   Modal,
   ScrollView,
+  Keyboard,
+  TouchableWithoutFeedback,
+  Platform,
+  KeyboardAvoidingView,
 } from 'react-native';
 import { colors as defaultColors, spacing, typography, commonStyles } from '../utils/theme';
 import { useRTL } from '../hooks/useRTL';
@@ -23,6 +27,8 @@ import { ScreenWrapper } from '../components/ScreenWrapper';
 import { useAppNavigation, SCREEN_NAMES } from '../hooks/useNavigation';
 import { MoreDropdown } from '../components/MoreDropdown';
 import { useTranslation } from 'react-i18next';
+import { WasteFilterModal, WasteFilters, getDefaultFilters } from '../components/WasteFilterModal';
+import { useWasteFilters, WasteDataItem } from '../hooks/useWasteFilters';
 
 // Dynamic chart config based on theme
 const getChartConfig = (isDarkMode: boolean) => ({
@@ -35,27 +41,70 @@ const getChartConfig = (isDarkMode: boolean) => ({
     ? `rgba(255, 255, 255, ${opacity})`
     : `rgba(0, 0, 0, ${opacity})`,
   barPercentage: 0.7,
-  decimalPlaces: 0,
+  decimalPlaces: 2,
 });
 
-const WASTE_TYPES = [
+const WASTE_TYPES_DEFAULT = [
   { key: 'PLASTIC', label: 'Plastic' },
   { key: 'PAPER', label: 'Paper' },
   { key: 'GLASS', label: 'Glass' },
   { key: 'METAL', label: 'Metal' },
+  { key: 'ELECTRONIC', label: 'Electronic' },
+  { key: 'OIL&FATS', label: 'Oil & Fats' },
+  { key: 'ORGANIC', label: 'Organic' },
 ];
+
+// Unit conversions for each waste type (labelKey -> grams per unit)
+const UNIT_CONVERSIONS: Record<string, { labelKey: string; grams: number }[]> = {
+  PLASTIC: [
+    { labelKey: 'plasticBottle', grams: 25 },
+    { labelKey: 'plasticBag', grams: 5 },
+    { labelKey: 'plasticCup', grams: 3 },
+  ],
+  PAPER: [
+    { labelKey: 'paperSheet', grams: 5 },
+    { labelKey: 'notebook', grams: 80 },
+  ],
+  GLASS: [
+    { labelKey: 'glassBottle', grams: 200 },
+    { labelKey: 'glassJar', grams: 150 },
+  ],
+  METAL: [
+    { labelKey: 'aluminumCan', grams: 15 },
+    { labelKey: 'metalSpoon', grams: 30 },
+  ],
+  ELECTRONIC: [
+    { labelKey: 'phoneCharger', grams: 100 },
+    { labelKey: 'usbCable', grams: 30 },
+  ],
+  'OIL&FATS': [
+    { labelKey: 'cookingOil', grams: 14 },
+    { labelKey: 'butterWrapper', grams: 1 },
+  ],
+  ORGANIC: [
+    { labelKey: 'bananaPeel', grams: 25 },
+    { labelKey: 'appleCore', grams: 20 },
+    { labelKey: 'foodScraps', grams: 50 },
+  ],
+};
+
+// Input method types
+type InputMethod = 'grams' | 'unit' | '';
 
 export const HomeScreen: React.FC = () => {
   const { t } = useTranslation();
   const { isRTL, textStyle, rowStyle } = useRTL();
   const { colors, isDarkMode } = useTheme();
 
-  // Waste types with translations
+  // Waste types with translations (all 7 types from backend)
   const WASTE_TYPES = [
     { key: 'PLASTIC', label: t('home.wasteTypes.PLASTIC') },
     { key: 'PAPER', label: t('home.wasteTypes.PAPER') },
     { key: 'GLASS', label: t('home.wasteTypes.GLASS') },
     { key: 'METAL', label: t('home.wasteTypes.METAL') },
+    { key: 'ELECTRONIC', label: t('home.wasteTypes.ELECTRONIC') },
+    { key: 'OIL&FATS', label: t('home.wasteTypes.OIL&FATS') },
+    { key: 'ORGANIC', label: t('home.wasteTypes.ORGANIC') },
   ];
   const { logout, userData } = useAuth();
   const { navigateToScreen } = useAppNavigation();
@@ -65,12 +114,47 @@ export const HomeScreen: React.FC = () => {
   const [wasteQuantity, setWasteQuantity] = useState('');
   const [showWasteTypeModal, setShowWasteTypeModal] = useState(false);
   const [selectedWasteType, setSelectedWasteType] = useState<{ key: string; label: string } | null>(null);
+  
+  // New states for two-method input (grams/unit)
+  const [inputMethod, setInputMethod] = useState<InputMethod>('');
+  const [showMethodModal, setShowMethodModal] = useState(false);
+  const [selectedUnitOption, setSelectedUnitOption] = useState<string>('');
+  const [showUnitModal, setShowUnitModal] = useState(false);
+  const [unitCount, setUnitCount] = useState('');
+
+  // Calculate grams when using unit method
+  const calculatedGrams = inputMethod === 'unit' && selectedUnitOption && unitCount && selectedWasteType
+    ? (() => {
+        const conv = UNIT_CONVERSIONS[selectedWasteType.key]?.find(u => u.labelKey === selectedUnitOption);
+        return conv ? conv.grams * parseInt(unitCount) : 0;
+      })()
+    : 0;
+
+  // Total grams based on method
+  const totalGrams = inputMethod === 'grams' 
+    ? (parseFloat(wasteQuantity) || 0) 
+    : calculatedGrams;
+  
+  // Warning thresholds
+  const showWarning = totalGrams > 500;
+  const exceedsMaxLimit = totalGrams > 5000;
 
   // data state
-  const [wasteData, setWasteData] = useState<any[]>([]);
+  const [wasteData, setWasteData] = useState<WasteDataItem[]>([]);
   const [loadingWaste, setLoadingWaste] = useState(true);
   const [tips, setTips] = useState<any[]>([]);
   const [loadingTips, setLoadingTips] = useState(true);
+
+  // Filter hook for waste data
+  const {
+    filters,
+    filteredData,
+    filtersActive,
+    isFilterModalVisible,
+    openFilterModal,
+    closeFilterModal,
+    applyFilters,
+  } = useWasteFilters(wasteData);
 
   // weather state
   const [weather, setWeather] = useState<{ temperature: number; weathercode: number } | null>(null);
@@ -150,25 +234,49 @@ export const HomeScreen: React.FC = () => {
 
   // add a new waste entry
   const handleAddWaste = async () => {
-    if (!selectedWasteType || !wasteQuantity) {
-      Alert.alert('Error', 'Please select a waste type and enter quantity');
+    if (!selectedWasteType || !inputMethod) {
+      Alert.alert(t('common.error'), t('wasteHelper.selectTypeAndMethod'));
       return;
     }
-    
-    const quantity = parseFloat(wasteQuantity);
-    if (isNaN(quantity) || quantity <= 0) {
-      Alert.alert('Error', 'Please enter a valid quantity (positive number)');
+
+    let gramsToSend = 0;
+
+    if (inputMethod === 'grams') {
+      gramsToSend = parseFloat(wasteQuantity);
+      if (isNaN(gramsToSend) || gramsToSend <= 0) {
+        Alert.alert(t('common.error'), t('wasteHelper.enterValidQuantity'));
+        return;
+      }
+    } else if (inputMethod === 'unit') {
+      if (!selectedUnitOption || !unitCount) {
+        Alert.alert(t('common.error'), t('wasteHelper.selectUnitAndCount'));
+        return;
+      }
+      gramsToSend = calculatedGrams;
+    }
+
+    if (gramsToSend <= 0) {
+      Alert.alert(t('common.error'), t('wasteHelper.enterValidQuantity'));
+      return;
+    }
+
+    if (exceedsMaxLimit) {
+      Alert.alert(t('common.error'), t('wasteHelper.excessiveAmountError'));
       return;
     }
 
     try {
       await wasteService.addUserWaste(
         selectedWasteType.key,
-        quantity
+        gramsToSend
       );
+      // Reset all fields
       setWasteType('');
       setWasteQuantity('');
       setSelectedWasteType(null);
+      setInputMethod('');
+      setSelectedUnitOption('');
+      setUnitCount('');
       fetchWasteData();
       Alert.alert(t('common.success'), t('home.addWaste'));
     } catch (error: any) {
@@ -184,20 +292,62 @@ export const HomeScreen: React.FC = () => {
     setSelectedWasteType(wasteType);
     setWasteType(wasteType.label);
     setShowWasteTypeModal(false);
+    // Reset method and unit selections when waste type changes
+    setInputMethod('');
+    setSelectedUnitOption('');
+    setUnitCount('');
+    setWasteQuantity('');
   };
 
-  // prepare chart data with translated labels
+  // handle input method selection
+  const handleMethodSelect = (method: InputMethod) => {
+    setInputMethod(method);
+    setShowMethodModal(false);
+    // Reset quantities when method changes
+    setWasteQuantity('');
+    setSelectedUnitOption('');
+    setUnitCount('');
+  };
+
+  // handle unit option selection
+  const handleUnitSelect = (labelKey: string) => {
+    setSelectedUnitOption(labelKey);
+    setShowUnitModal(false);
+  };
+
+  // Get available unit options for selected waste type
+  const availableUnits = selectedWasteType ? UNIT_CONVERSIONS[selectedWasteType.key] || [] : [];
+
+  // Input methods for dropdown
+  const INPUT_METHODS = [
+    { key: 'grams' as InputMethod, label: t('wasteHelper.methods.grams') },
+    { key: 'unit' as InputMethod, label: t('wasteHelper.methods.unit') },
+  ];
+
+  // Check if add button should be disabled
+  const isAddDisabled = 
+    !selectedWasteType || 
+    !inputMethod || 
+    (inputMethod === 'grams' && !wasteQuantity) ||
+    (inputMethod === 'unit' && (!selectedUnitOption || !unitCount)) ||
+    exceedsMaxLimit;
+
+  // prepare chart data with translated labels (using filtered data)
   const screenWidth = Dimensions.get('window').width - 32;
-  const barLabels = wasteData.map((i) => {
+  const barLabels = filteredData.map((i) => {
     const wasteType = i.waste_type?.toUpperCase();
     // Translate waste type if translation exists, otherwise use original
     const translated = t(`home.wasteTypes.${wasteType}`, { defaultValue: i.waste_type });
     // Truncate labels to max 6 chars to fit on mobile
     return translated.length > 6 ? translated.substring(0, 5) + '.' : translated;
   });
-  const barData = wasteData.map((i) => i.total_amount || 0);
+  // Convert grams to kg for display (backend stores in grams, chart shows kg)
+  const barData = filteredData.map((i) => (i.total_amount || 0) / 1000);
   // Chart fits screen width - labels are rotated to fit
   const chartWidth = screenWidth;
+  
+  // Check if there's any data to display
+  const hasData = barData.some(val => val > 0);
 
   // tip item renderer
   const renderTipItem = ({ item }: { item: any }) => (
@@ -248,11 +398,43 @@ export const HomeScreen: React.FC = () => {
 
       {/* Bar chart */}
       <View style={styles.chartContainer}>
-        <Text style={[styles.sectionTitle, textStyle, { color: colors.primary }]}>{t('home.wasteHistory')}</Text>
+        <View style={[styles.chartHeaderRow, rowStyle]}>
+          <Text style={[styles.sectionTitle, textStyle, { color: colors.primary }]}>{t('home.wasteHistory')}</Text>
+          <TouchableOpacity
+            style={[
+              styles.filterButton,
+              { 
+                backgroundColor: filtersActive ? colors.primary : colors.backgroundSecondary,
+                borderColor: colors.primary,
+              },
+            ]}
+            onPress={openFilterModal}
+            accessibilityRole="button"
+            accessibilityLabel={t('filter.filterButton')}
+            accessibilityHint={filtersActive ? t('filter.activeFilters') : undefined}
+          >
+            <Text style={[
+              styles.filterButtonText,
+              { color: filtersActive ? colors.textOnPrimary : colors.primary }
+            ]}>
+              {filtersActive ? `⚡ ${t('filter.filterButton')}` : `🔍 ${t('filter.filterButton')}`}
+            </Text>
+          </TouchableOpacity>
+        </View>
+        
+        {/* Active filters indicator */}
+        {filtersActive && (
+          <View style={[styles.activeFiltersBar, { backgroundColor: colors.backgroundSecondary }]}>
+            <Text style={[styles.activeFiltersText, { color: colors.textSecondary }]}>
+              {t(`filter.timeRanges.${filters.timeRange}`)} • {filters.wasteTypes.length} {t('filter.wasteTypes').toLowerCase()}
+            </Text>
+          </View>
+        )}
+        
         <View style={[styles.chartPlaceholder, { backgroundColor: colors.backgroundSecondary }]}>
           {loadingWaste ? (
             <Text style={{ color: colors.textSecondary }}>[Loading waste data...]</Text>
-          ) : barData.length > 0 ? (
+          ) : hasData ? (
             <BarChart
               data={{ labels: barLabels, datasets: [{ data: barData }] }}
               width={chartWidth}
@@ -270,43 +452,200 @@ export const HomeScreen: React.FC = () => {
               style={{ borderRadius: 12, marginLeft: -16 }}
             />
           ) : (
-            <Text style={{ color: colors.textSecondary }}>{t('home.noWasteLogged')}</Text>
+            <View style={styles.emptyChartContainer}>
+              <Text style={[styles.emptyChartText, { color: colors.textSecondary }]}>
+                {filtersActive ? t('filter.noDataForFilters') : t('home.noWasteLogged')}
+              </Text>
+              {filtersActive && (
+                <TouchableOpacity
+                  style={[styles.clearFiltersButton, { borderColor: colors.primary }]}
+                  onPress={openFilterModal}
+                >
+                  <Text style={[styles.clearFiltersText, { color: colors.primary }]}>
+                    {t('filter.clearAll')}
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
           )}
         </View>
       </View>
 
+      {/* Waste Filter Modal */}
+      <WasteFilterModal
+        visible={isFilterModalVisible}
+        onClose={closeFilterModal}
+        onApply={applyFilters}
+        currentFilters={filters}
+      />
+
       {/* Spacer */}
       <View style={{ height: spacing.xl + spacing.sm }} />
 
-      {/* Waste logging inputs */}
-      <View style={styles.logRow}>
-        <TouchableOpacity
-          style={[styles.wasteTypeButton, { backgroundColor: colors.background, borderColor: colors.lightGray }]}
-          onPress={() => setShowWasteTypeModal(true)}
-        >
-          <Text style={[styles.wasteTypeButtonText, { color: colors.textPrimary }, !selectedWasteType && { color: colors.textSecondary }]} numberOfLines={1}>
-            {selectedWasteType ? selectedWasteType.label : t('home.selectWasteType')}
+      {/* Warning Message for high amounts */}
+      {showWarning && (
+        <View style={[
+          styles.warningBox, 
+          { 
+            backgroundColor: colors.backgroundSecondary,
+            borderLeftColor: exceedsMaxLimit ? '#dc2626' : '#059669',
+          }
+        ]}>
+          <Text style={styles.warningIcon}>⚠️</Text>
+          <Text style={[styles.warningText, { color: exceedsMaxLimit ? '#dc2626' : '#059669' }]}>
+            {exceedsMaxLimit 
+              ? t('wasteHelper.excessiveAmountError') 
+              : t('wasteHelper.highAmountWarning')}
           </Text>
-          <Text style={[styles.dropdownArrow, { color: colors.textSecondary }]}>▼</Text>
-        </TouchableOpacity>
+        </View>
+      )}
 
-        <TextInput
-          style={[styles.quantityInput, { backgroundColor: colors.background, borderColor: colors.lightGray, color: colors.textPrimary }]}
-          placeholder="0.0"
-          placeholderTextColor={colors.textSecondary}
-          value={wasteQuantity}
-          onChangeText={setWasteQuantity}
-          keyboardType="numeric"
-        />
+      {/* Waste logging inputs - Row 1: Waste Type & Method */}
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <View style={styles.logRow}>
+          {/* Waste Type Dropdown */}
+          <TouchableOpacity
+            style={[styles.wasteTypeButton, { backgroundColor: colors.background, borderColor: colors.lightGray, flex: 1 }]}
+            onPress={() => {
+              Keyboard.dismiss();
+              setShowWasteTypeModal(true);
+            }}
+          >
+            <Text style={[styles.wasteTypeButtonText, { color: colors.textPrimary }, !selectedWasteType && { color: colors.textSecondary }]} numberOfLines={1}>
+              {selectedWasteType ? selectedWasteType.label : t('home.selectWasteType')}
+            </Text>
+            <Text style={[styles.dropdownArrow, { color: colors.textSecondary }]}>▼</Text>
+          </TouchableOpacity>
 
-        <TouchableOpacity
-          style={[styles.addButton, { backgroundColor: colors.primary }, (!selectedWasteType || !wasteQuantity) && { backgroundColor: colors.lightGray, opacity: 0.6 }]}
-          onPress={handleAddWaste}
-          disabled={!selectedWasteType || !wasteQuantity}
-        >
-          <Text style={[styles.addButtonText, { color: colors.textOnPrimary }]}>{t('home.addWaste')}</Text>
-        </TouchableOpacity>
-      </View>
+          {/* Method Dropdown */}
+          <TouchableOpacity
+            style={[
+              styles.methodButton, 
+              { backgroundColor: colors.background, borderColor: colors.lightGray },
+              !selectedWasteType && styles.disabledButton
+            ]}
+            onPress={() => {
+              if (selectedWasteType) {
+                Keyboard.dismiss();
+                setShowMethodModal(true);
+              }
+            }}
+            disabled={!selectedWasteType}
+          >
+            <Text 
+              style={[
+                styles.wasteTypeButtonText, 
+                { color: colors.textPrimary }, 
+                !inputMethod && { color: colors.textSecondary }
+              ]} 
+              numberOfLines={1}
+            >
+              {inputMethod ? t(`wasteHelper.methods.${inputMethod}`) : t('wasteHelper.selectMethod')}
+            </Text>
+            <Text style={[styles.dropdownArrow, { color: colors.textSecondary }]}>▼</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableWithoutFeedback>
+
+      {/* Waste logging inputs - Row 2: Unit/Grams & Add Button */}
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <View style={[styles.logRow, { marginTop: spacing.xs }]}>
+          {inputMethod === 'unit' ? (
+            <>
+              {/* Unit Type Dropdown */}
+              <TouchableOpacity
+                style={[
+                  styles.unitButton, 
+                  { backgroundColor: colors.background, borderColor: colors.lightGray },
+                  !inputMethod && styles.disabledButton
+                ]}
+                onPress={() => {
+                  if (inputMethod === 'unit') {
+                    Keyboard.dismiss();
+                    setShowUnitModal(true);
+                  }
+                }}
+                disabled={inputMethod !== 'unit'}
+              >
+                <Text 
+                  style={[
+                    styles.wasteTypeButtonText, 
+                    { color: colors.textPrimary }, 
+                    !selectedUnitOption && { color: colors.textSecondary }
+                  ]} 
+                  numberOfLines={1}
+                >
+                  {selectedUnitOption 
+                    ? `${t(`wasteHelper.items.${selectedUnitOption}`)} (${availableUnits.find(u => u.labelKey === selectedUnitOption)?.grams}g)`
+                    : t('wasteHelper.chooseItem')}
+                </Text>
+                <Text style={[styles.dropdownArrow, { color: colors.textSecondary }]}>▼</Text>
+              </TouchableOpacity>
+
+              {/* Unit Count Input */}
+              <TextInput
+                style={[
+                  styles.quantityInput, 
+                  { backgroundColor: colors.background, borderColor: colors.lightGray, color: colors.textPrimary },
+                  !selectedUnitOption && styles.disabledInput
+                ]}
+                placeholder={t('wasteHelper.count')}
+                placeholderTextColor={colors.textSecondary}
+                value={unitCount}
+                onChangeText={setUnitCount}
+                keyboardType="numeric"
+                returnKeyType="done"
+                blurOnSubmit={true}
+                onSubmitEditing={Keyboard.dismiss}
+                editable={!!selectedUnitOption}
+              />
+
+              {/* Calculated Grams Display */}
+              <View style={[styles.gramsDisplay, { backgroundColor: colors.backgroundSecondary, borderColor: colors.lightGray }]}>
+                <Text style={[styles.gramsDisplayText, { color: colors.textPrimary }]}>
+                  {calculatedGrams > 0 ? `${calculatedGrams}g` : '0g'}
+                </Text>
+              </View>
+            </>
+          ) : (
+            <>
+              {/* Grams Input */}
+              <TextInput
+                style={[
+                  styles.gramsInput, 
+                  { backgroundColor: colors.background, borderColor: colors.lightGray, color: colors.textPrimary },
+                  inputMethod !== 'grams' && styles.disabledInput
+                ]}
+                placeholder={t('wasteHelper.quantityGrams')}
+                placeholderTextColor={colors.textSecondary}
+                value={wasteQuantity}
+                onChangeText={setWasteQuantity}
+                keyboardType="numeric"
+                returnKeyType="done"
+                blurOnSubmit={true}
+                onSubmitEditing={Keyboard.dismiss}
+                editable={inputMethod === 'grams'}
+              />
+            </>
+          )}
+
+          {/* Add Button */}
+          <TouchableOpacity
+            style={[
+              styles.addButton, 
+              { backgroundColor: colors.primary }, 
+              isAddDisabled && { backgroundColor: colors.lightGray, opacity: 0.6 }
+            ]}
+            onPress={() => {
+              Keyboard.dismiss();
+              handleAddWaste();
+            }}
+            disabled={isAddDisabled}
+          >
+            <Text style={[styles.addButtonText, { color: colors.textOnPrimary }]}>{t('home.addWaste')}</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableWithoutFeedback>
 
       {/* Waste Type Selection Modal */}
       <Modal
@@ -332,6 +671,75 @@ export const HomeScreen: React.FC = () => {
             <TouchableOpacity
               style={[styles.modalCloseButton, { backgroundColor: colors.lightGray }]}
               onPress={() => setShowWasteTypeModal(false)}
+            >
+              <Text style={[styles.modalCloseButtonText, { color: colors.textPrimary }]}>{t('common.cancel')}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Method Selection Modal */}
+      <Modal
+        visible={showMethodModal}
+        transparent={true}
+        animationType="slide"
+        onRequestClose={() => setShowMethodModal(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={[styles.modalContent, { backgroundColor: colors.background }]}>
+            <Text style={[styles.modalTitle, textStyle, { color: colors.primary }]}>{t('wasteHelper.selectMethod')}</Text>
+            <ScrollView style={styles.wasteTypeList}>
+              {INPUT_METHODS.map((method) => (
+                <TouchableOpacity
+                  key={method.key}
+                  style={[styles.wasteTypeItem, { borderBottomColor: colors.lightGray }]}
+                  onPress={() => handleMethodSelect(method.key)}
+                >
+                  <Text style={[styles.wasteTypeItemText, textStyle, { color: colors.textPrimary }]}>{method.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <TouchableOpacity
+              style={[styles.modalCloseButton, { backgroundColor: colors.lightGray }]}
+              onPress={() => setShowMethodModal(false)}
+            >
+              <Text style={[styles.modalCloseButtonText, { color: colors.textPrimary }]}>{t('common.cancel')}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Unit Selection Modal */}
+      <Modal
+        visible={showUnitModal}
+        transparent={true}
+        animationType="slide"
+        onRequestClose={() => setShowUnitModal(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={[styles.modalContent, { backgroundColor: colors.background }]}>
+            <Text style={[styles.modalTitle, textStyle, { color: colors.primary }]}>{t('wasteHelper.chooseItem')}</Text>
+            <ScrollView style={styles.wasteTypeList}>
+              {availableUnits.map((unit) => (
+                <TouchableOpacity
+                  key={unit.labelKey}
+                  style={[styles.wasteTypeItem, { borderBottomColor: colors.lightGray }]}
+                  onPress={() => handleUnitSelect(unit.labelKey)}
+                >
+                  <View style={styles.unitItemRow}>
+                    <Text style={[styles.wasteTypeItemText, textStyle, { color: colors.textPrimary }]}>
+                      {t(`wasteHelper.items.${unit.labelKey}`)}
+                    </Text>
+                    <Text style={[styles.unitGramsText, { color: colors.textSecondary }]}>
+                      {unit.grams}g
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <TouchableOpacity
+              style={[styles.modalCloseButton, { backgroundColor: colors.lightGray }]}
+              onPress={() => setShowUnitModal(false)}
             >
               <Text style={[styles.modalCloseButtonText, { color: colors.textPrimary }]}>{t('common.cancel')}</Text>
             </TouchableOpacity>
@@ -380,10 +788,60 @@ const styles = StyleSheet.create({
   chartContainer: {
     marginBottom: spacing.md,
   },
+  chartHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
   sectionTitle: {
     ...typography.h2,
     color: defaultColors.primary,
     marginBottom: spacing.xs,
+  },
+  filterButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: 20,
+    borderWidth: 1,
+    minHeight: MIN_TOUCH_TARGET,
+  },
+  filterButtonText: {
+    ...typography.caption,
+    fontWeight: '600',
+  },
+  activeFiltersBar: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: 8,
+    marginBottom: spacing.xs,
+  },
+  activeFiltersText: {
+    ...typography.caption,
+    textAlign: 'center',
+  },
+  emptyChartContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  emptyChartText: {
+    ...typography.body,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  clearFiltersButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 8,
+    borderWidth: 1,
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+  },
+  clearFiltersText: {
+    ...typography.button,
   },
   chartPlaceholder: {
     minHeight: 260,
@@ -453,6 +911,89 @@ const styles = StyleSheet.create({
     color: defaultColors.gray,
     fontSize: 12,
     marginLeft: spacing.xs,
+  },
+  methodButton: {
+    flex: 0.7,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: defaultColors.white,
+    borderWidth: 1,
+    borderColor: defaultColors.lightGray,
+    borderRadius: 8,
+    paddingHorizontal: spacing.sm,
+    height: 44,
+    marginLeft: spacing.xs,
+  },
+  unitButton: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: defaultColors.white,
+    borderWidth: 1,
+    borderColor: defaultColors.lightGray,
+    borderRadius: 8,
+    paddingHorizontal: spacing.sm,
+    height: 44,
+  },
+  gramsInput: {
+    flex: 1,
+    backgroundColor: defaultColors.white,
+    borderWidth: 1,
+    borderColor: defaultColors.lightGray,
+    borderRadius: 8,
+    paddingHorizontal: spacing.sm,
+    height: 44,
+  },
+  gramsDisplay: {
+    backgroundColor: defaultColors.lightGray,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: spacing.sm,
+    height: 44,
+    width: 60,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: spacing.xs,
+  },
+  gramsDisplayText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  disabledInput: {
+    opacity: 0.5,
+  },
+  warningBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 8,
+    borderLeftWidth: 4,
+    marginBottom: spacing.sm,
+  },
+  warningIcon: {
+    fontSize: 18,
+    marginRight: spacing.sm,
+  },
+  warningText: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  unitItemRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+  },
+  unitGramsText: {
+    fontSize: 14,
+    fontWeight: '500',
   },
   modalOverlay: {
     flex: 1,

--- a/application/mobile/src/utils/__tests__/wasteConversions.test.ts
+++ b/application/mobile/src/utils/__tests__/wasteConversions.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for waste unit conversions and data transformations
+ */
+
+// Unit conversion definitions (must match HomeScreen.tsx)
+const UNIT_CONVERSIONS: Record<string, { labelKey: string; grams: number }[]> = {
+  PLASTIC: [
+    { labelKey: 'plasticBottle', grams: 25 },
+    { labelKey: 'plasticBag', grams: 5 },
+    { labelKey: 'plasticCup', grams: 3 },
+  ],
+  PAPER: [
+    { labelKey: 'paperSheet', grams: 5 },
+    { labelKey: 'notebook', grams: 80 },
+  ],
+  GLASS: [
+    { labelKey: 'glassBottle', grams: 200 },
+    { labelKey: 'glassJar', grams: 150 },
+  ],
+  METAL: [
+    { labelKey: 'aluminumCan', grams: 15 },
+    { labelKey: 'metalSpoon', grams: 30 },
+  ],
+  ELECTRONIC: [
+    { labelKey: 'phoneCharger', grams: 100 },
+    { labelKey: 'usbCable', grams: 30 },
+  ],
+  'OIL&FATS': [
+    { labelKey: 'cookingOil', grams: 14 },
+    { labelKey: 'butterWrapper', grams: 1 },
+  ],
+  ORGANIC: [
+    { labelKey: 'bananaPeel', grams: 25 },
+    { labelKey: 'appleCore', grams: 20 },
+    { labelKey: 'foodScraps', grams: 50 },
+  ],
+};
+
+// Helper function to calculate grams from unit
+const calculateGramsFromUnit = (
+  wasteType: string,
+  unitLabelKey: string,
+  count: number
+): number => {
+  const units = UNIT_CONVERSIONS[wasteType];
+  if (!units) return 0;
+  
+  const unit = units.find(u => u.labelKey === unitLabelKey);
+  if (!unit) return 0;
+  
+  return unit.grams * count;
+};
+
+// Helper function to convert grams to kg for chart display
+const gramsToKg = (grams: number): number => {
+  return grams / 1000;
+};
+
+describe('Waste Unit Conversions', () => {
+  describe('UNIT_CONVERSIONS structure', () => {
+    it('should have all 7 waste types defined', () => {
+      const expectedTypes = ['PLASTIC', 'PAPER', 'GLASS', 'METAL', 'ELECTRONIC', 'OIL&FATS', 'ORGANIC'];
+      
+      expectedTypes.forEach(type => {
+        expect(UNIT_CONVERSIONS[type]).toBeDefined();
+        expect(Array.isArray(UNIT_CONVERSIONS[type])).toBe(true);
+        expect(UNIT_CONVERSIONS[type].length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should have valid gram values for all units', () => {
+      Object.values(UNIT_CONVERSIONS).forEach(units => {
+        units.forEach(unit => {
+          expect(unit.grams).toBeGreaterThan(0);
+          expect(typeof unit.labelKey).toBe('string');
+          expect(unit.labelKey.length).toBeGreaterThan(0);
+        });
+      });
+    });
+  });
+
+  describe('calculateGramsFromUnit', () => {
+    it('should calculate plastic bottle grams correctly', () => {
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 1)).toBe(25);
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 4)).toBe(100);
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 10)).toBe(250);
+    });
+
+    it('should calculate plastic bag grams correctly', () => {
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBag', 1)).toBe(5);
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBag', 20)).toBe(100);
+    });
+
+    it('should calculate glass bottle grams correctly', () => {
+      expect(calculateGramsFromUnit('GLASS', 'glassBottle', 1)).toBe(200);
+      expect(calculateGramsFromUnit('GLASS', 'glassBottle', 5)).toBe(1000);
+    });
+
+    it('should calculate glass jar grams correctly', () => {
+      expect(calculateGramsFromUnit('GLASS', 'glassJar', 2)).toBe(300);
+    });
+
+    it('should calculate paper items correctly', () => {
+      expect(calculateGramsFromUnit('PAPER', 'paperSheet', 100)).toBe(500);
+      expect(calculateGramsFromUnit('PAPER', 'notebook', 1)).toBe(80);
+    });
+
+    it('should calculate metal items correctly', () => {
+      expect(calculateGramsFromUnit('METAL', 'aluminumCan', 10)).toBe(150);
+      expect(calculateGramsFromUnit('METAL', 'metalSpoon', 3)).toBe(90);
+    });
+
+    it('should calculate electronic items correctly', () => {
+      expect(calculateGramsFromUnit('ELECTRONIC', 'phoneCharger', 2)).toBe(200);
+      expect(calculateGramsFromUnit('ELECTRONIC', 'usbCable', 5)).toBe(150);
+    });
+
+    it('should calculate oil & fats items correctly', () => {
+      expect(calculateGramsFromUnit('OIL&FATS', 'cookingOil', 10)).toBe(140);
+      expect(calculateGramsFromUnit('OIL&FATS', 'butterWrapper', 50)).toBe(50);
+    });
+
+    it('should calculate organic items correctly', () => {
+      expect(calculateGramsFromUnit('ORGANIC', 'bananaPeel', 4)).toBe(100);
+      expect(calculateGramsFromUnit('ORGANIC', 'appleCore', 5)).toBe(100);
+      expect(calculateGramsFromUnit('ORGANIC', 'foodScraps', 2)).toBe(100);
+    });
+
+    it('should return 0 for invalid waste type', () => {
+      expect(calculateGramsFromUnit('INVALID', 'plasticBottle', 5)).toBe(0);
+    });
+
+    it('should return 0 for invalid unit labelKey', () => {
+      expect(calculateGramsFromUnit('PLASTIC', 'invalidUnit', 5)).toBe(0);
+    });
+
+    it('should handle zero count', () => {
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 0)).toBe(0);
+    });
+  });
+
+  describe('gramsToKg (Chart Display Conversion)', () => {
+    it('should convert grams to kg correctly', () => {
+      expect(gramsToKg(1000)).toBe(1);
+      expect(gramsToKg(500)).toBe(0.5);
+      expect(gramsToKg(100)).toBe(0.1);
+      expect(gramsToKg(2500)).toBe(2.5);
+    });
+
+    it('should handle small amounts', () => {
+      expect(gramsToKg(25)).toBe(0.025);
+      expect(gramsToKg(5)).toBe(0.005);
+      expect(gramsToKg(1)).toBe(0.001);
+    });
+
+    it('should handle zero', () => {
+      expect(gramsToKg(0)).toBe(0);
+    });
+
+    it('should handle large amounts', () => {
+      expect(gramsToKg(10000)).toBe(10);
+      expect(gramsToKg(50000)).toBe(50);
+    });
+  });
+
+  describe('Warning Thresholds', () => {
+    const WARNING_THRESHOLD = 500;
+    const MAX_LIMIT = 5000;
+
+    it('should identify amounts needing warning (>500g)', () => {
+      expect(600 > WARNING_THRESHOLD).toBe(true);
+      expect(1000 > WARNING_THRESHOLD).toBe(true);
+      expect(500 > WARNING_THRESHOLD).toBe(false);
+      expect(499 > WARNING_THRESHOLD).toBe(false);
+    });
+
+    it('should identify amounts exceeding max limit (>5000g)', () => {
+      expect(5001 > MAX_LIMIT).toBe(true);
+      expect(6000 > MAX_LIMIT).toBe(true);
+      expect(5000 > MAX_LIMIT).toBe(false);
+      expect(4999 > MAX_LIMIT).toBe(false);
+    });
+
+    it('should calculate when unit selections exceed warning', () => {
+      // 21 plastic bottles = 21 * 25g = 525g (warning)
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 21)).toBe(525);
+      expect(525 > WARNING_THRESHOLD).toBe(true);
+
+      // 3 glass bottles = 3 * 200g = 600g (warning)
+      expect(calculateGramsFromUnit('GLASS', 'glassBottle', 3)).toBe(600);
+      expect(600 > WARNING_THRESHOLD).toBe(true);
+    });
+
+    it('should calculate when unit selections exceed max limit', () => {
+      // 201 plastic bottles = 201 * 25g = 5025g (max exceeded)
+      expect(calculateGramsFromUnit('PLASTIC', 'plasticBottle', 201)).toBe(5025);
+      expect(5025 > MAX_LIMIT).toBe(true);
+
+      // 26 glass bottles = 26 * 200g = 5200g (max exceeded)
+      expect(calculateGramsFromUnit('GLASS', 'glassBottle', 26)).toBe(5200);
+      expect(5200 > MAX_LIMIT).toBe(true);
+    });
+  });
+});
+
+describe('Chart Data Transformation', () => {
+  // Simulate what HomeScreen does with filteredData
+  const transformWasteDataForChart = (wasteData: { waste_type: string; total_amount: number }[]) => {
+    return wasteData.map(item => ({
+      label: item.waste_type,
+      value: gramsToKg(item.total_amount), // Convert to kg
+    }));
+  };
+
+  it('should transform backend data correctly for chart', () => {
+    const backendData = [
+      { waste_type: 'PLASTIC', total_amount: 1000 },
+      { waste_type: 'PAPER', total_amount: 500 },
+      { waste_type: 'GLASS', total_amount: 2500 },
+    ];
+
+    const chartData = transformWasteDataForChart(backendData);
+
+    expect(chartData).toEqual([
+      { label: 'PLASTIC', value: 1 },    // 1000g = 1kg
+      { label: 'PAPER', value: 0.5 },    // 500g = 0.5kg
+      { label: 'GLASS', value: 2.5 },    // 2500g = 2.5kg
+    ]);
+  });
+
+  it('should handle empty data', () => {
+    const chartData = transformWasteDataForChart([]);
+    expect(chartData).toEqual([]);
+  });
+
+  it('should handle zero amounts', () => {
+    const backendData = [
+      { waste_type: 'PLASTIC', total_amount: 0 },
+    ];
+
+    const chartData = transformWasteDataForChart(backendData);
+    expect(chartData[0].value).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
Implements visualization customization (RQ-1 1.2.3) with two input methods for waste logging.

## Changes
### New Features
- **Two input methods**: Users can add waste by grams or by item (unit)
- **Unit conversions**: Predefined items with gram values (plastic bottle=25g, glass jar=150g, etc.)
- **Filtering functionality**: Filtering for time and waste type
- **Additional Waste Types**: Added "Electronics", "Oil&Fats" and "Organic" waste types
- **Warning system**: Shows warning >500g, blocks >5000g
- **Chart fix**: Grams now correctly converted to kg for display

### Files Changed
- `HomeScreen.tsx` - Two-method input UI
- `ProfileScreen.tsx` - Chart kg conversion fix
- `en.json`, `tr.json`, `es.json`, `fr.json`, `ar.json` - Translations
- `wasteConversions.test.ts` - Unit tests (25 tests)

## Testing
- ✅ 45 unit tests passing
- ✅ Manual testing on Expo

